### PR TITLE
Use check-exn correctly

### DIFF
--- a/test/all-defined-out.rkt
+++ b/test/all-defined-out.rkt
@@ -19,4 +19,4 @@
   (lambda (e)
     (string-contains? (exn-message e) "s1: undefined"))
   (lambda ()
-    (eval '(s1 x))) 5)
+    (eval '(s1 x))))


### PR DESCRIPTION
The third argument is probably unintentional from copy-and-paste
(especially judging from its placement which is not on its own line).
So this PR removes it.